### PR TITLE
only include dist, license and bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "*.md",
     "sandbox",
     "src",
+    "tests",
     "gulpfile.js",
     "package.json"
   ]


### PR DESCRIPTION
also added main entry

to avoid "invalid-meta" warning from bower
